### PR TITLE
Add Git cloning and LaTeX container support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Backend
 PORT=3000
 DATABASE_URL=postgresql://user:password@localhost:5432/underleaf
+REPO_BASE_PATH=./repos
 
 # Frontend
 VITE_API_URL=http://localhost:3000

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 **/node_modules
 **/dist
 **/.env
+repos

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ npm install
 
 # Set up environment variables
 cp .env.example .env
+# Directory where cloned repositories will be stored
+# (can be customized via REPO_BASE_PATH)
 
 # Start development servers
 npm run dev

--- a/backend/package.json
+++ b/backend/package.json
@@ -8,11 +8,15 @@
     "start": "node dist/index.js"
   },
   "dependencies": {
-    "express": "^4.18.2"
+    "express": "^4.18.2",
+    "simple-git": "^3.19.1",
+    "fs-extra": "^11.1.1"
   },
   "devDependencies": {
     "typescript": "^5.0.0",
     "@types/express": "^4.17.17",
-    "ts-node-dev": "^2.0.0"
+    "ts-node-dev": "^2.0.0",
+    "@types/node": "^18.17.1",
+    "@types/fs-extra": "^11.0.4"
   }
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,10 +1,65 @@
 import express from 'express';
+import path from 'path';
+import fs from 'fs-extra';
+import simpleGit from 'simple-git';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+
+const execAsync = promisify(exec);
 
 const app = express();
 const port = process.env.PORT || 3000;
+// Base directory for cloned repositories. Each user will have a
+// separate subdirectory once authentication is implemented.
+const REPO_BASE_PATH = process.env.REPO_BASE_PATH || path.join(__dirname, '..', '..', 'repos');
+
+app.use(express.json());
 
 app.get('/', (_req, res) => {
   res.send('Underleaf backend');
+});
+
+app.post('/api/clone', async (req, res) => {
+  const { repoUrl, userId = 'anonymous' } = req.body as { repoUrl?: string; userId?: string };
+  if (!repoUrl) {
+    return res.status(400).json({ error: 'repoUrl is required' });
+  }
+
+  // Store repositories under a user-specific directory so that a real
+  // authentication system can isolate projects in the future.
+  const userPath = path.join(REPO_BASE_PATH, userId);
+  const repoName = path.basename(repoUrl, '.git');
+  const repoPath = path.join(userPath, repoName);
+
+  try {
+    await fs.ensureDir(userPath);
+    const git = simpleGit();
+    await git.clone(repoUrl, repoPath);
+    return res.json({ message: 'Repository cloned', path: repoPath });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: 'Failed to clone repository' });
+  }
+});
+
+app.post('/api/compile', async (req, res) => {
+  const { userId = 'anonymous', repoName, texFile = 'main.tex' } = req.body as { userId?: string; repoName?: string; texFile?: string };
+  if (!repoName) {
+    return res.status(400).json({ error: 'repoName is required' });
+  }
+
+  const repoPath = path.join(REPO_BASE_PATH, userId, repoName);
+  // Use the latex container to compile the document. This keeps the
+  // compilation environment isolated from the Node.js process.
+  const dockerCommand = `docker run --rm -v ${repoPath}:/workdir latex pdflatex ${texFile}`;
+
+  try {
+    await execAsync(dockerCommand);
+    return res.json({ message: 'Compilation finished' });
+  } catch (err) {
+    console.error(err);
+    return res.status(500).json({ error: 'Compilation failed' });
+  }
 });
 
 app.listen(port, () => {

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -2,10 +2,12 @@
   "compilerOptions": {
     "target": "ES2019",
     "module": "commonjs",
+    "moduleResolution": "node",
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "types": ["node"]
   },
   "include": ["src"],
   "exclude": ["node_modules"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,3 +18,10 @@ services:
     volumes:
       - ../frontend:/app
     command: npm run dev
+  latex:
+    build:
+      context: ./latex
+      dockerfile: Dockerfile
+    volumes:
+      - ../repos:/workdir
+    command: tail -f /dev/null

--- a/docker/latex/Dockerfile
+++ b/docker/latex/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu:22.04
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y texlive-full && \
+    rm -rf /var/lib/apt/lists/*
+WORKDIR /workdir
+CMD ["bash"]

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,28 @@
 # Documentation
 
 Project documentation will be placed here.
+
+## Backend API
+
+### `POST /api/clone`
+
+Clone a Git repository into a user specific directory. Example body:
+
+```json
+{
+  "repoUrl": "https://github.com/user/project.git",
+  "userId": "test-user"
+}
+```
+
+### `POST /api/compile`
+
+Compile a LaTeX document using the `latex` Docker container. Example body:
+
+```json
+{
+  "repoName": "project",
+  "userId": "test-user",
+  "texFile": "main.tex"
+}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,19 +10,41 @@
         "backend"
       ],
       "devDependencies": {
+        "@types/fs-extra": "^11.0.4",
         "concurrently": "^8.2.0"
       }
     },
     "backend": {
       "version": "0.1.0",
       "dependencies": {
-        "express": "^4.18.2"
+        "express": "^4.18.2",
+        "fs-extra": "^11.1.1",
+        "simple-git": "^3.19.1"
       },
       "devDependencies": {
         "@types/express": "^4.17.17",
+        "@types/fs-extra": "^11.0.4",
+        "@types/node": "^18.17.1",
         "ts-node-dev": "^2.0.0",
         "typescript": "^5.0.0"
       }
+    },
+    "backend/node_modules/@types/node": {
+      "version": "18.19.111",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.111.tgz",
+      "integrity": "sha512-90sGdgA+QLJr1F9X79tQuEut0gEYIfkX9pydI4XGRgvFo9g2JWswefI+WUSUHPYVBHYSEfTEqBxA5hQvAZB3Mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "backend/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
     },
     "frontend": {
       "version": "0.1.0",
@@ -785,6 +807,21 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@kwsites/file-exists": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+      "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1"
+      }
+    },
+    "node_modules/@kwsites/promise-deferred": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+      "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.9",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.9.tgz",
@@ -912,12 +949,33 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/fs-extra": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-11.0.4.tgz",
+      "integrity": "sha512-yTbItCNreRooED33qjunPthRcSjERP1r4MqCZc7wv0u2sUkzTFp45tgUfS5+r7FrZPdmCCNflLhVSP/o+SemsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/jsonfile": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/http-errors": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
       "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/jsonfile": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/@types/jsonfile/-/jsonfile-6.1.4.tgz",
+      "integrity": "sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/mime": {
       "version": "1.3.5",
@@ -1517,7 +1575,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1835,6 +1892,20 @@
       "resolved": "frontend",
       "link": true
     },
+    "node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -1979,6 +2050,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -2171,6 +2248,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/lodash": {
@@ -2851,6 +2940,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-git": {
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-3.28.0.tgz",
+      "integrity": "sha512-Rs/vQRwsn1ILH1oBUy8NucJlXmnnLeLCfcvbSehkPzbv3wwoFWIdtfd6Ndo6ZPhlPsCZ60CPI4rxurnwAa+a2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@kwsites/file-exists": "^1.1.1",
+        "@kwsites/promise-deferred": "^1.1.1",
+        "debug": "^4.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/steveukx/git-js?sponsor=1"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -3138,6 +3242,15 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,15 @@
 {
   "name": "underleaf",
   "private": true,
-  "workspaces": ["frontend", "backend"],
+  "workspaces": [
+    "frontend",
+    "backend"
+  ],
   "scripts": {
     "dev": "concurrently -k -n frontend,backend -c green.bold,blue.bold \"npm --workspace frontend run dev\" \"npm --workspace backend run dev\""
   },
   "devDependencies": {
+    "@types/fs-extra": "^11.0.4",
     "concurrently": "^8.2.0"
   }
 }


### PR DESCRIPTION
## Summary
- configure repo storage via `REPO_BASE_PATH`
- implement `/api/clone` and `/api/compile` endpoints
- add LaTeX Docker image and compose service
- document new API routes
- update example environment vars and ignore cloned repos

## Testing
- `npm --workspace backend run build`

------
https://chatgpt.com/codex/tasks/task_e_68429a4f5dc0832b8130255c65d37b3b