### PR TITLE
Integrate clone & compile API calls

### DIFF
--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -2,11 +2,27 @@ import Editor from '@monaco-editor/react';
 import FileTree from '../components/FileTree';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { compileRepo } from '../utils/api';
 
 export default function EditorPage() {
   const navigate = useNavigate();
   const repoUrl = sessionStorage.getItem('repoUrl') || '';
   const [content, setContent] = useState('% Start writing your LaTeX here');
+
+  const repoName = repoUrl
+    ? repoUrl.split('/').pop()?.replace(/\.git$/, '') || ''
+    : '';
+
+  const handleCompile = async () => {
+    if (!repoName) return;
+    try {
+      await compileRepo(repoName);
+      alert('Compilation finished');
+    } catch (err) {
+      alert('Compilation failed');
+      console.error(err);
+    }
+  };
 
   if (!repoUrl) {
     navigate('/');
@@ -14,8 +30,9 @@ export default function EditorPage() {
 
   return (
     <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
-      <header style={{ padding: '0.5rem', background: '#f5f5f5' }}>
+      <header style={{ padding: '0.5rem', background: '#f5f5f5', display: 'flex', justifyContent: 'space-between' }}>
         <span>Repo: {repoUrl}</span>
+        <button onClick={handleCompile}>Compile</button>
       </header>
       <div style={{ flex: 1, display: 'flex' }}>
         <aside style={{ width: '200px', borderRight: '1px solid #ddd' }}>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,16 +1,23 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { cloneRepo } from '../utils/api';
 
 export default function Home() {
   const [url, setUrl] = useState('');
   const navigate = useNavigate();
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (url.trim()) {
-      // Save the URL (for now just in sessionStorage)
+    if (!url.trim()) return;
+
+    try {
+      await cloneRepo(url.trim());
+      // Save the URL for use in the editor
       sessionStorage.setItem('repoUrl', url.trim());
       navigate('/editor');
+    } catch (err) {
+      alert('Failed to clone repository');
+      console.error(err);
     }
   };
 

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,0 +1,25 @@
+const API_URL = import.meta.env.VITE_API_URL || '';
+
+export async function cloneRepo(repoUrl: string, userId = 'anonymous') {
+  const res = await fetch(`${API_URL}/api/clone`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ repoUrl, userId })
+  });
+  if (!res.ok) {
+    throw new Error('Failed to clone repository');
+  }
+  return res.json();
+}
+
+export async function compileRepo(repoName: string, userId = 'anonymous', texFile = 'main.tex') {
+  const res = await fetch(`${API_URL}/api/compile`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ repoName, userId, texFile })
+  });
+  if (!res.ok) {
+    throw new Error('Failed to compile repository');
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add API helpers for cloning and compiling
- clone repository when submitting repo URL
- allow compiling the repo from the editor

## Testing
- `npm test` *(fails: Missing script)*
- `npm --workspace frontend run build` *(fails: `vite` not found)*
- `npm --workspace backend run build` *(fails: missing type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_68429e1d82dc832ba78e40640736d29a