### PR TITLE
Improve home page UI

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,4 +1,5 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap');
 
 body {
   margin: 0;
@@ -13,6 +14,7 @@ body {
 }
 
 h1 {
+  font-family: 'Poppins', sans-serif;
   font-size: 2.5rem;
   font-weight: 600;
   margin: 0;
@@ -71,8 +73,22 @@ section.preview {
 
 .home-form {
   display: flex;
-  gap: 0.5rem;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
   margin-top: 1rem;
+}
+
+.home-form input {
+  width: 100%;
+  max-width: 500px;
+  padding: 0.75rem 1rem;
+  border-radius: 9999px;
+}
+
+.hint-text {
+  opacity: 0.7;
+  font-size: 0.9rem;
 }
 
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -27,11 +27,10 @@ export default function Home() {
       <form onSubmit={handleSubmit} className="home-form">
         <input
           type="url"
-          placeholder="Enter Git repository URL"
           value={url}
           onChange={(e) => setUrl(e.target.value)}
-          style={{ minWidth: '300px' }}
         />
+        <p className="hint-text">Enter Git repository URL</p>
         <button type="submit">Open</button>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- add Poppins font for the title
- center the home form and style the URL input with rounded borders
- show hint text below the input field

## Testing
- `npm --workspace frontend run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842a5c5e1a4832b9ed5214dc12908bb