### PR TITLE
Fix cloning error and update docs

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -33,9 +33,15 @@ app.post('/api/clone', async (req, res) => {
 
   try {
     await fs.ensureDir(userPath);
-    const git = simpleGit();
-    await git.clone(repoUrl, repoPath);
-    return res.json({ message: 'Repository cloned', path: repoPath });
+    if (await fs.pathExists(repoPath)) {
+      const repoGit = simpleGit(repoPath);
+      await repoGit.pull();
+      return res.json({ message: 'Repository updated', path: repoPath });
+    } else {
+      const git = simpleGit();
+      await git.clone(repoUrl, repoPath);
+      return res.json({ message: 'Repository cloned', path: repoPath });
+    }
   } catch (err) {
     console.error(err);
     return res.status(500).json({ error: 'Failed to clone repository' });

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,9 @@ Project documentation will be placed here.
 
 ### `POST /api/clone`
 
-Clone a Git repository into a user specific directory. Example body:
+Clone a Git repository into a user specific directory. If the repository
+already exists for that user, it will be updated using `git pull`.
+Example body:
 
 ```json
 {

--- a/frontend/src/pages/Editor.tsx
+++ b/frontend/src/pages/Editor.tsx
@@ -30,8 +30,10 @@ export default function EditorPage() {
 
   return (
     <div style={{ height: '100vh', display: 'flex', flexDirection: 'column' }}>
-      <header style={{ padding: '0.5rem', background: '#f5f5f5', display: 'flex', justifyContent: 'space-between' }}>
-      <header className="app-header">
+      <header
+        className="app-header"
+        style={{ padding: '0.5rem', background: '#f5f5f5', display: 'flex', justifyContent: 'space-between' }}
+      >
         <span>Repo: {repoUrl}</span>
         <button onClick={handleCompile}>Compile</button>
       </header>


### PR DESCRIPTION
## Summary
- handle existing repo path in `POST /api/clone`
- clarify clone endpoint behavior in the docs
- fix markup error in `Editor.tsx`

## Testing
- `npm --workspace backend run build`
- `npm --workspace frontend run build`


------
https://chatgpt.com/codex/tasks/task_e_6842a58c4018832b83d553dde5b54505